### PR TITLE
feat(sprint-1): add manifesto and truth pages

### DIFF
--- a/docs/manifesto/index.md
+++ b/docs/manifesto/index.md
@@ -1,6 +1,19 @@
 ---
-title: "PLACEHOLDER"
-status: "draft"
+title: "Dopamine as Mythic Engine"
+tags: ["primer","myth:dukkha"]
+takeaway: "Reframe dopamine from chemical to cultural force."
+status: "review"
 updated: "2025-08-15"
 ---
-Section placeholder. Content forthcoming.
+
+{{ thesis_card(title="Thesis", takeaway="Wanting ≠ liking; autonomy requires reading the reward map.", refs=["schultz1997","berridge2009"]) }}
+
+{{ caution_callout(heading="Scope", body="This is a field guide, not medical advice.") }}
+
+Intro: Why “Dukkha” matters; map over microscope; cultural drift and design.
+
+**Key Premise**
+- Dopamine steers attention via prediction error and salience.
+- Systems exploit variable reward → doomscrolling, compulsion loops.
+
+_Scholia Mode →_ [References](../library/index.md#references)

--- a/docs/truth/index.md
+++ b/docs/truth/index.md
@@ -1,6 +1,16 @@
 ---
-title: "PLACEHOLDER"
-status: "draft"
+title: "Desire ≠ Pleasure"
+tags: ["misconception","incentive-salience"]
+takeaway: "Incentive salience drives seeking even without pleasure."
+status: "review"
 updated: "2025-08-15"
 ---
-Section placeholder. Content forthcoming.
+
+Desire is not identical to pleasure; it is often stronger when pleasure is absent.
+
+{{ thesis_card(title="Core Claim", takeaway="Wanting is separable from liking and learning.", refs=["berridge2009"]) }}
+
+{{ glossary_term(term="incentive salience") }}
+
+- Evidence sketch and implications for daily behavior.
+- Practice link → craving reset protocol (forthcoming).


### PR DESCRIPTION
## Summary
- add manifesto page with thesis and scope callout
- add truth page outlining incentive salience

## Testing
- `pip install mkdocs mkdocs-material mkdocs-bibtex mkdocs-macros-plugin mkdocs-awesome-pages-plugin mkdocs-glightbox pymdown-extensions mkdocs-gen-files` (failed: Could not connect to proxy, 403)
- `mkdocs build` (command not found)


------
https://chatgpt.com/codex/tasks/task_e_689f600ee28c83238ce11f56c04eec49