### PR TITLE
feat(sprint-2): add Model Atlas page with placeholder diagram

### DIFF
--- a/docs/assets/figures/atlas-wll.svg
+++ b/docs/assets/figures/atlas-wll.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <circle cx="50" cy="50" r="40" stroke="black" stroke-width="2" fill="none" />
+</svg>

--- a/docs/model/index.md
+++ b/docs/model/index.md
@@ -1,6 +1,15 @@
 ---
-title: "PLACEHOLDER"
+title: "Atlas: Wanting–Liking–Learning"
+tags: ["model","triad"]
+takeaway: "Three systems, distinct yet coupled."
 status: "draft"
 updated: "2025-08-15"
 ---
-Section placeholder. Content forthcoming.
+
+{{ figure_with_caption(src="/assets/figures/atlas-wll.svg", caption="The W–L–L Triad.", id="fig-wll-atlas") }}
+
+{{ protocol_steps(steps=[
+  "Start with Wanting (salience/approach).",
+  "Differentiate Liking (hedonic tone).",
+  "Track Learning (RPE-driven updates).",
+]) }}


### PR DESCRIPTION
## Summary
- add Wanting–Liking–Learning Atlas page with captioned placeholder diagram

## Testing
- `mkdocs build` *(fails: command not found)*
- `pip install mkdocs mkdocs-material mkdocs-bibtex mkdocs-macros-plugin mkdocs-awesome-pages-plugin mkdocs-glightbox pymdown-extensions mkdocs-gen-files` *(fails: Could not find a version that satisfies the requirement mkdocs; 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689f6b8bcfc883238fb5b9aa29d6730d