### PR TITLE
feat(sprint-3): add 48-Hour Craving Reset protocol

### DIFF
--- a/docs/practice/index.md
+++ b/docs/practice/index.md
@@ -1,6 +1,18 @@
 ---
-title: "PLACEHOLDER"
+title: "The 48‑Hour Craving Reset"
+tags: ["protocol","reset"]
+takeaway: "Reduce variable rewards; restore signal clarity."
 status: "draft"
 updated: "2025-08-15"
 ---
-Section placeholder. Content forthcoming.
+
+{{ caution_callout(heading="Safety", body="Behavioral routine only; stop if distress escalates.") }}
+
+{{ myth_science_pair(myth="Icarus", insight="Over-prediction of reward under novelty inflates risk-taking.") }}
+
+{{ protocol_steps(steps=[
+  "Prepare: Identify variable reward cues (apps/sites) and remove for 48h.",
+  "Replace: Pre-plan alternative activities (walk, call friend, read).",
+  "Observe: Note craving peaks; use 2×5 min breathwork windows.",
+  "Reflect: After 48h, reintroduce selectively with time boxes."
+]) }}


### PR DESCRIPTION
## Summary
- add 48-Hour Craving Reset protocol page (draft)

## Testing
- `mkdocs build` *(fails: command not found: mkdocs)*

------
https://chatgpt.com/codex/tasks/task_e_689f6d6fdbf48323a6cee1b15cbf6bb9