### PR TITLE
feat(sprint-4): add brief and library index

### DIFF
--- a/docs/briefs/index.md
+++ b/docs/briefs/index.md
@@ -1,6 +1,12 @@
 ---
-title: "PLACEHOLDER"
+title: "Doomscrolling & Variable Reward"
+tags: ["brief","intermittent-reinforcement"]
+takeaway: "Intermittent schedules maximize attention capture."
 status: "draft"
 updated: "2025-08-15"
 ---
-Section placeholder. Content forthcoming.
+
+Mechanism overview; checklist of anti-patterns; links to Truth and Practice.
+
+- See: [Desire ≠ Pleasure](../truth/index.md)
+- Use: [Craving Reset](../practice/index.md)

--- a/docs/library/index.md
+++ b/docs/library/index.md
@@ -1,6 +1,13 @@
 ---
-title: "PLACEHOLDER"
+title: "Library"
 status: "draft"
 updated: "2025-08-15"
 ---
-Section placeholder. Content forthcoming.
+
+# References
+Citations are managed via BibTeX in `docs/data/references.bib`.
+(Full render can be enhanced with templates later.)
+
+# Glossary
+- {{ glossary_term(term="incentive salience") }}
+- {{ glossary_term(term="reward prediction error") }}


### PR DESCRIPTION
## Summary
- add Doomscrolling & Variable Reward brief page
- add Library index with placeholder references and glossary hooks

## Testing
- `mkdocs build` *(fails: command not found)*
- `pip install mkdocs mkdocs-material mkdocs-bibtex mkdocs-macros-plugin mkdocs-awesome-pages-plugin mkdocs-glightbox pymdown-extensions mkdocs-gen-files` *(fails: ProxyError 403)*

------
https://chatgpt.com/codex/tasks/task_e_689f6f1490b083238c905ed3fb113ca5