### PR TITLE
Add dopamine and attention diagrams

### DIFF
--- a/docs/images/diagrams/dopamine_baseline_spike.svg
+++ b/docs/images/diagrams/dopamine_baseline_spike.svg
@@ -1,0 +1,27 @@
+<svg viewBox="0 0 400 250" xmlns="http://www.w3.org/2000/svg" aria-labelledby="dopamineGraphTitle dopamineGraphDesc">
+    <title id="dopamineGraphTitle">Dopamine Baseline vs. Spike</title>
+    <desc id="dopamineGraphDesc">A line graph showing a sharp dopamine spike followed by a dip below baseline over time.</desc>
+
+    <defs>
+        <marker id="arrowhead-axis" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+            <polygon points="0 0, 10 3.5, 0 7" fill="var(--color-text-muted)" />
+        </marker>
+    </defs>
+
+    <!-- Axes -->
+    <line x1="50" y1="200" x2="350" y2="200" stroke="var(--color-text-muted)" stroke-width="1.5" marker-end="url(#arrowhead-axis)"></line> <!-- X-axis -->
+    <line x1="50" y1="200" x2="50" y2="50" stroke="var(--color-text-muted)" stroke-width="1.5" marker-end="url(#arrowhead-axis)"></line>   <!-- Y-axis -->
+
+    <!-- Axis Labels -->
+    <text x="350" y="215" text-anchor="end" fill="var(--color-text-secondary)" font-size="12" font-family="var(--font-sans)">Time</text>
+    <text x="35" y="140" text-anchor="middle" fill="var(--color-text-secondary)" font-size="12" font-family="var(--font-sans)" transform="rotate(-90 35 140)">Dopamine Level (Relative)</text>
+
+    <!-- Baseline (dashed line) -->
+    <line x1="50" y1="120" x2="350" y2="120" stroke="var(--color-text-muted)" stroke-dasharray="4 2" stroke-width="1.5"></line>
+    <text x="355" y="125" text-anchor="start" fill="var(--color-text-muted)" font-size="11" font-family="var(--font-sans)">Baseline</text>
+
+    <!-- Dopamine Level curve - Smoother path -->
+    <path d="M50,120 C 70,120 85,70 110,50 C135,30 160,180 185,190 C210,200 240,150 270,130 C300,110 325,115 350,120"
+          fill="none" stroke="var(--color-accent)" stroke-width="3" stroke-linecap="round"></path>
+    <text x="180" y="40" text-anchor="middle" fill="var(--color-accent)" font-size="11" font-family="var(--font-sans)">Dopamine Level</text>
+</svg>

--- a/docs/images/diagrams/ping_scroll_loop.svg
+++ b/docs/images/diagrams/ping_scroll_loop.svg
@@ -1,0 +1,83 @@
+<svg viewBox="0 0 680 400" xmlns="http://www.w3.org/2000/svg" aria-labelledby="pingScrollTitle pingScrollDesc">
+    <title id="pingScrollTitle">The Ping/Scroll Loop</title>
+    <desc id="pingScrollDesc">A flowchart illustrating the digital distraction loop: External Cue leads to Anticipation & Craving, which leads to Interrupting current task for checking feed, then Brief Relief, and cycles back to External Cue. Intervention points are shown to break the loop.</desc>
+
+    <defs>
+        <!-- Arrowhead for solid main loop arrows -->
+        <marker id="arrowhead-solid" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+            <polygon points="0 0, 10 3.5, 0 7" fill="var(--color-text-secondary)" />
+        </marker>
+        <!-- Arrowhead for accent loop arrow -->
+        <marker id="arrowhead-accent" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+            <polygon points="0 0, 10 3.5, 0 7" fill="var(--color-accent)" />
+        </marker>
+        <!-- Arrowhead for dashed intervention lines -->
+        <marker id="arrowhead-dashed" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+            <polygon points="0 0, 10 3.5, 0 7" fill="var(--color-text-muted)" />
+        </marker>
+    </defs>
+
+    <!-- Node Definitions -->
+    <!-- External Cue / Boredom -->
+    <rect x="50" y="180" width="200" height="80" rx="12" ry="12" fill="var(--color-surface-elevated)" stroke="var(--color-border)" stroke-width="2"></rect>
+    <text x="150" y="210" text-anchor="middle" fill="var(--color-text-primary)" font-size="16" font-family="var(--font-sans)">External Cue</text>
+    <text x="150" y="230" text-anchor="middle" fill="var(--color-text-primary)" font-size="16" font-family="var(--font-sans)">/ Boredom</text>
+
+    <!-- Anticipation & Craving (Dopamine Spike) -->
+    <rect x="240" y="40" width="200" height="80" rx="12" ry="12" fill="var(--color-accent)" stroke="var(--color-accent)" stroke-width="2"></rect>
+    <text x="340" y="70" text-anchor="middle" fill="var(--color-background)" font-size="16" font-family="var(--font-sans)">Anticipation &amp;</text>
+    <text x="340" y="90" text-anchor="middle" fill="var(--color-background)" font-size="16" font-family="var(--font-sans)">Craving (Dopamine Spike)</text>
+
+    <!-- Interrupt Current Task to Check Feed -->
+    <rect x="430" y="180" width="200" height="80" rx="12" ry="12" fill="var(--color-surface-elevated)" stroke="var(--color-border)" stroke-width="2"></rect>
+    <text x="530" y="210" text-anchor="middle" fill="var(--color-text-primary)" font-size="16" font-family="var(--font-sans)">Interrupt Current</text>
+    <text x="530" y="230" text-anchor="middle" fill="var(--color-text-primary)" font-size="16" font-family="var(--font-sans)">Task to Check Feed</text>
+
+    <!-- Brief Relief (Dopamine Spike) / Variable Reward -->
+    <rect x="240" y="300" width="200" height="80" rx="12" ry="12" fill="var(--color-surface-elevated)" stroke="var(--color-border)" stroke-width="2"></rect>
+    <text x="340" y="330" text-anchor="middle" fill="var(--color-text-primary)" font-size="16" font-family="var(--font-sans)">Brief Relief</text>
+    <text x="340" y="350" text-anchor="middle" fill="var(--color-text-primary)" font-size="16" font-family="var(--font-sans)">(Dopamine Spike)</text>
+    <text x="340" y="370" text-anchor="middle" fill="var(--color-text-primary)" font-size="16" font-family="var(--font-sans)">/ Variable Reward</text>
+
+
+    <!-- Cycle Arrows -->
+    <!-- Anticipation & Craving (Accent) -> Interrupt Current Task -->
+    <path d="M400 120 C 500 150 530 180 530 180" fill="none" stroke="var(--color-accent)" stroke-width="2.5" marker-end="url(#arrowhead-accent)"></path>
+    <!-- Interrupt Current Task -> Brief Relief -->
+    <path d="M480 260 C 400 280 380 300 380 300" fill="none" stroke="var(--color-text-secondary)" stroke-width="2" marker-end="url(#arrowhead-solid)"></path>
+    <!-- Brief Relief -> External Cue -->
+    <path d="M280 380 C 180 290 150 260 150 260" fill="none" stroke="var(--color-text-secondary)" stroke-width="2" marker-end="url(#arrowhead-solid)"></path>
+    <!-- External Cue -> Anticipation & Craving -->
+    <path d="M180 180 C 250 150 280 120 280 120" fill="none" stroke="var(--color-text-secondary)" stroke-width="2" marker-end="url(#arrowhead-solid)"></path>
+
+    <!-- Intervention Nodes -->
+    <!-- Top-Left Intervention Box -->
+    <rect x="60" y="40" width="100" height="40" rx="8" ry="8" fill="var(--color-surface-elevated)" stroke="var(--color-border)" stroke-width="1"></rect>
+    <text x="110" y="65" text-anchor="middle" fill="var(--color-text-primary)" font-size="14" font-family="var(--font-sans)">Intervention</text>
+
+    <!-- Turn Off Cue -->
+    <rect x="90" y="300" width="140" height="40" rx="8" ry="8" fill="var(--color-surface-elevated)" stroke="var(--color-border)" stroke-width="1"></rect>
+    <text x="160" y="325" text-anchor="middle" fill="var(--color-text-primary)" font-size="14" font-family="var(--font-sans)">Turn Off Cue</text>
+
+    <!-- Mindful Pause -->
+    <rect x="470" y="300" width="140" height="40" rx="8" ry="8" fill="var(--color-surface-elevated)" stroke="var(--color-border)" stroke-width="1"></rect>
+    <text x="540" y="325" text-anchor="middle" fill="var(--color-text-primary)" font-size="14" font-family="var(--font-sans)">Mindful</text>
+    <text x="540" y="345" text-anchor="middle" fill="var(--color-text-primary)" font-size="14" font-family="var(--font-sans)">Pause</text>
+
+    <!-- Intervention Arrows (Dashed Lines) -->
+    <!-- From Top-Left Intervention Box to Anticipation & Craving -->
+    <line x1="160" y1="60" x2="238" y2="60" stroke="var(--color-text-secondary)" stroke-width="1.5" stroke-dasharray="6 3" marker-end="url(#arrowhead-dashed)"></line>
+
+    <!-- From External Cue to Turn Off Cue -->
+    <line x1="150" y1="260" x2="150" y2="300" stroke="var(--color-text-muted)" stroke-width="1.5" stroke-dasharray="6 3" marker-end="url(#arrowhead-dashed)"></line>
+    <text x="150" y="280" text-anchor="middle" fill="var(--color-text-muted)" font-size="12" font-family="var(--font-sans)">Intervention</text>
+
+    <!-- From Interrupt Current Task to Mindful Pause -->
+    <line x1="530" y1="260" x2="530" y2="300" stroke="var(--color-text-muted)" stroke-width="1.5" stroke-dasharray="6 3" marker-end="url(#arrowhead-dashed)"></line>
+    <text x="530" y="280" text-anchor="middle" fill="var(--color-text-muted)" font-size="12" font-family="var(--font-sans)">Mindful Pause</text>
+
+    <!-- From Anticipation & Craving to Interrupt Current Task (alternative path, dashed) -->
+    <path d="M440 90 C 470 140 480 180 480 180" fill="none" stroke="var(--color-text-muted)" stroke-width="1.5" stroke-dasharray="6 3" marker-end="url(#arrowhead-dashed)"></path>
+    <text x="470" y="150" text-anchor="middle" fill="var(--color-text-muted)" font-size="12" font-family="var(--font-sans)">Intervention</text>
+
+</svg>

--- a/docs/images/diagrams/reward_compass.svg
+++ b/docs/images/diagrams/reward_compass.svg
@@ -1,0 +1,38 @@
+<svg viewBox="0 0 500 400" xmlns="http://www.w3.org/2000/svg" aria-labelledby="rewardCompassTitle rewardCompassDesc">
+    <title id="rewardCompassTitle">The Reward Compass</title>
+    <desc id="rewardCompassDesc">A 2D coordinate plane showing Dopamine Baseline Level and Sensitivity vs. Tolerance, with conceptual zones.</desc>
+
+    <!-- Axes -->
+    <line x1="50" y1="350" x2="450" y2="350" stroke="var(--color-text-muted)" stroke-width="1.5"></line> <!-- X-axis -->
+    <line x1="250" y1="50" x2="250" y2="350" stroke="var(--color-text-muted)" stroke-width="1.5"></line> <!-- Y-axis -->
+
+    <!-- Axis Labels -->
+    <text x="450" y="365" text-anchor="end" fill="var(--color-text-secondary)" font-size="12" font-family="var(--font-sans)">Spike vs. Sensitivity</text>
+    <text x="250" y="380" text-anchor="middle" fill="var(--color-text-secondary)" font-size="10" font-family="var(--font-sans)">(High Spikes / Low Sensitivity &rarr; Low Spikes / High Sensitivity)</text>
+
+    <text x="265" y="55" text-anchor="start" fill="var(--color-text-secondary)" font-size="12" font-family="var(--font-sans)" transform="rotate(-90 265 55)">Baseline Level</text>
+    <text x="240" y="65" text-anchor="end" fill="var(--color-text-secondary)" font-size="10" font-family="var(--font-sans)">(Low &rarr; High)</text>
+
+    <!-- Quadrant Backgrounds and Labels -->
+    <!-- Top-Left Quadrant: Optimal Flow / Contentment -->
+    <rect x="50" y="50" width="200" height="150" fill="var(--color-surface)" opacity="0.6"></rect>
+    <text x="150" y="125" text-anchor="middle" fill="var(--color-text-muted)" font-size="14" font-family="var(--font-sans)">Optimal Flow / Contentment</text>
+    <circle cx="150" cy="110" r="6" fill="var(--color-accent)"></circle> <!-- Clearer marker for optimal zone -->
+
+    <!-- Top-Right Quadrant: Compulsive Seeking / Burnout -->
+    <rect x="250" y="50" width="200" height="150" fill="var(--color-surface-elevated)" opacity="0.6"></rect>
+    <text x="350" y="125" text-anchor="middle" fill="var(--color-text-muted)" font-size="14" font-family="var(--font-sans)">Compulsive Seeking / Burnout</text>
+
+    <!-- Bottom-Left Quadrant: Low Drive / Anhedonia -->
+    <rect x="50" y="200" width="200" height="150" fill="var(--color-surface-elevated)" opacity="0.6"></rect>
+    <text x="150" y="275" text-anchor="middle" fill="var(--color-text-muted)" font-size="14" font-family="var(--font-sans)">Low Drive / Anhedonia</text>
+
+    <!-- Bottom-Right Quadrant: High Spikes / Low Sensitivity -->
+    <rect x="250" y="200" width="200" height="150" fill="var(--color-surface)" opacity="0.6"></rect>
+    <text x="350" y="275" text-anchor="middle" fill="var(--color-text-muted)" font-size="14" font-family="var(--font-sans)">High Spikes / Low Sensitivity</text>
+
+    <!-- Subtle Compass Motif -->
+    <circle cx="250" cy="200" r="8" fill="var(--color-accent)" stroke="var(--color-background)" stroke-width="2"></circle>
+    <line x1="250" y1="190" x2="250" y2="210" stroke="var(--color-background)" stroke-width="1.5"></line>
+    <line x1="240" y1="200" x2="260" y2="200" stroke="var(--color-background)" stroke-width="1.5"></line>
+</svg>

--- a/docs/images/diagrams/stress_sensitization_loop.svg
+++ b/docs/images/diagrams/stress_sensitization_loop.svg
@@ -1,0 +1,67 @@
+<svg viewBox="0 0 680 650" xmlns="http://www.w3.org/2000/svg" aria-labelledby="stressSensitizationTitle stressSensitizationDesc">
+    <title id="stressSensitizationTitle">The Stress-Reward Sensitization Loop and How to Break It</title>
+    <desc id="stressSensitizationDesc">A flowchart depicting how acute stress leads to impulsive reward-seeking, negative baseline drops, and self-reinforcing stress, with strategic exit points shown.</desc>
+
+    <defs>
+        <marker id="arrowhead-solid-stress" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+            <polygon points="0 0, 10 3.5, 0 7" fill="var(--color-text-secondary)" />
+        </marker>
+        <marker id="arrowhead-dashed-stress" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+            <polygon points="0 0, 10 3.5, 0 7" fill="var(--color-text-muted)" />
+        </marker>
+    </defs>
+
+    <!-- Main Loop Nodes (Vertical flow, then curve back) -->
+    <!-- Stress / Anxiety -->
+    <rect x="240" y="40" width="200" height="60" rx="12" ry="12" fill="var(--color-surface-elevated)" stroke="var(--color-border)" stroke-width="2"></rect>
+    <text x="340" y="75" text-anchor="middle" fill="var(--color-text-primary)" font-size="16" font-family="var(--font-sans)">Stress / Anxiety</text>
+
+    <!-- Attention on Quick Rewards -->
+    <rect x="240" y="140" width="200" height="60" rx="12" ry="12" fill="var(--color-surface-elevated)" stroke="var(--color-border)" stroke-width="2"></rect>
+    <text x="340" y="175" text-anchor="middle" fill="var(--color-text-primary)" font-size="16" font-family="var(--font-sans)">Attention on Quick Rewards</text>
+
+    <!-- Impulse / Short-term Reward-Seeking -->
+    <rect x="240" y="240" width="200" height="60" rx="12" ry="12" fill="var(--color-surface-elevated)" stroke="var(--color-border)" stroke-width="2"></rect>
+    <text x="340" y="275" text-anchor="middle" fill="var(--color-text-primary)" font-size="16" font-family="var(--font-sans)">Impulse / Short-term</text>
+    <text x="340" y="295" text-anchor="middle" fill="var(--color-text-primary)" font-size="16" font-family="var(--font-sans)">Reward-Seeking</text>
+
+    <!-- Brief Relief (Dopamine Spike) -->
+    <rect x="240" y="340" width="200" height="60" rx="12" ry="12" fill="var(--color-accent)" stroke="var(--color-accent)" stroke-width="2"></rect>
+    <text x="340" y="375" text-anchor="middle" fill="var(--color-background)" font-size="16" font-family="var(--font-sans)">Brief Relief</text>
+    <text x="340" y="395" text-anchor="middle" fill="var(--color-background)" font-size="16" font-family="var(--font-sans)">(Dopamine Spike)</text>
+
+    <!-- Baseline Drops (Mood, Energy Down) -->
+    <rect x="240" y="440" width="200" height="60" rx="12" ry="12" fill="var(--color-surface-elevated)" stroke="var(--color-border)" stroke-width="2"></rect>
+    <text x="340" y="475" text-anchor="middle" fill="var(--color-text-primary)" font-size="16" font-family="var(--font-sans)">Baseline Drops</text>
+    <text x="340" y="495" text-anchor="middle" fill="var(--color-text-primary)" font-size="16" font-family="var(--font-sans)">(Mood, Energy Down)</text>
+
+    <!-- More Stress, Regret or Fatigue -->
+    <rect x="240" y="540" width="200" height="60" rx="12" ry="12" fill="var(--color-surface-elevated)" stroke="var(--color-border)" stroke-width="2"></rect>
+    <text x="340" y="575" text-anchor="middle" fill="var(--color-text-primary)" font-size="16" font-family="var(--font-sans)">More Stress, Regret or Fatigue</text>
+
+    <!-- Main Loop Arrows -->
+    <path d="M340 100 V140" fill="none" stroke="var(--color-text-secondary)" stroke-width="2" marker-end="url(#arrowhead-solid-stress)"></path>
+    <path d="M340 200 V240" fill="none" stroke="var(--color-text-secondary)" stroke-width="2" marker-end="url(#arrowhead-solid-stress)"></path>
+    <path d="M340 300 V340" fill="none" stroke="var(--color-text-secondary)" stroke-width="2" marker-end="url(#arrowhead-solid-stress)"></path>
+    <path d="M340 400 V440" fill="none" stroke="var(--color-text-secondary)" stroke-width="2" marker-end="url(#arrowhead-solid-stress)"></path>
+    <path d="M340 500 V540" fill="none" stroke="var(--color-text-secondary)" stroke-width="2" marker-end="url(#arrowhead-solid-stress)"></path>
+    <!-- Curved arrow back to Stress / Anxiety -->
+    <path d="M340 600 C 150 650 100 550 100 350 C 100 150 300 0 340 40" fill="none" stroke="var(--color-text-secondary)" stroke-width="2" marker-end="url(#arrowhead-solid-stress)"></path>
+
+    <!-- Exit Points (Oval Nodes) -->
+    <!-- Exit: Breathwork or Pause -->
+    <rect x="20" y="60" width="160" height="50" rx="25" ry="25" fill="var(--color-surface)" stroke="var(--color-border)" stroke-width="2"></rect>
+    <text x="100" y="90" text-anchor="middle" fill="var(--color-text-primary)" font-size="14" font-family="var(--font-sans)">Exit: Breathwork or Pause</text>
+    <line x1="240" y1="70" x2="180" y2="85" stroke="var(--color-text-muted)" stroke-width="1.5" stroke-dasharray="6 3" marker-end="url(#arrowhead-dashed-stress)"></line>
+
+    <!-- Exit: Exercise or Social Support -->
+    <rect x="490" y="160" width="160" height="50" rx="25" ry="25" fill="var(--color-surface)" stroke="var(--color-border)" stroke-width="2"></rect>
+    <text x="570" y="190" text-anchor="middle" fill="var(--color-text-primary)" font-size="14" font-family="var(--font-sans)">Exit: Exercise or Social support</text>
+    <line x1="440" y1="170" x2="490" y2="185" stroke="var(--color-text-muted)" stroke-width="1.5" stroke-dasharray="6 3" marker-end="url(#arrowhead-dashed-stress)"></line>
+
+    <!-- Exit: Plan / Reflection -->
+    <rect x="20" y="370" width="160" height="50" rx="25" ry="25" fill="var(--color-surface)" stroke="var(--color-border)" stroke-width="2"></rect>
+    <text x="100" y="400" text-anchor="middle" fill="var(--color-text-primary)" font-size="14" font-family="var(--font-sans)">Exit: Plan / Reflection</text>
+    <line x1="240" y1="370" x2="180" y2="395" stroke="var(--color-text-muted)" stroke-width="1.5" stroke-dasharray="6 3" marker-end="url(#arrowhead-dashed-stress)"></line>
+
+</svg>

--- a/docs/site/attention.html
+++ b/docs/site/attention.html
@@ -62,7 +62,7 @@
         <section class="diagram-section">
             <h2>The Ping/Scroll Loop: A Vicious Cycle Explained</h2>
             <figure>
-                <img src="../images/diagrams/ping_scroll_loop_diagram.svg" alt="Diagram showing the Ping/Scroll Loop cycle with intervention points.">
+                <img src="../images/diagrams/ping_scroll_loop.svg" alt="Diagram illustrating the Ping/Scroll Loop cycle with intervention points." class="diagram-visual">
                 <figcaption>Figure 1: The Ping/Scroll Loop illustrates how an external cue or boredom triggers anticipation and craving (dopamine spike), leading to checking behavior. This can result in either a variable reward ("hit") or no reward ("miss"), both of which reinforce the cycle and increase craving for the next interaction. Strategic intervention points (dashed lines) can break this loop.</figcaption>
             </figure>
         </section>

--- a/docs/site/model.html
+++ b/docs/site/model.html
@@ -75,8 +75,8 @@
             <p>The "Reward Compass" provides a conceptual 2x2 matrix model to understand where your neurochemical state might lie based on your dopamine baseline level and sensitivity/tolerance. It helps identify functional zones such as "Low Drive / Anhedonia," "Compulsive Seeking / Burnout," and "Optimal Flow / Contentment." By consciously managing your exposure to high-dopamine stimuli and engaging in consistent recovery behaviors, you can steer your system towards a more balanced and intrinsically motivated state.</p>
             <p>For visual examples of conceptual models depicting reward system states or motivation matrices, you might explore diagrams related to "affective neuroscience" or "neurochemical balance" models. <sup><a href="#fn10" class="footnote-link">[10]</a></sup></p>
             <figure>
-              <img src="../images/placeholders/diagram_placeholder.svg" alt="Placeholder diagram for The Reward Compass - Visual representation coming soon." class="diagram-placeholder-image">
-              <figcaption><em>(Diagram: The Reward Compass - Custom visual representation coming soon.)</em></figcaption>
+                              <img src="../images/diagrams/reward_compass.svg" alt="Diagram showing the Reward Compass with axes for Baseline, Spikes, Sensitivity, and Tolerance, indicating optimal and suboptimal zones." class="diagram-visual">
+                <figcaption>Figure 3: The Reward Compass. This schema illustrates the interplay of dopamine baseline, spikes, sensitivity, and tolerance. Optimal states involve a healthy baseline and sensitivity to moderate rewards, while high tolerance from constant spiking can lead to a depleted baseline and perpetual seeking.</figcaption>
             </figure>
         </section>
     </main>

--- a/docs/site/recovery.html
+++ b/docs/site/recovery.html
@@ -60,19 +60,15 @@
 
         <section class="diagram-section">
             <h2>Understanding Your Dopamine Baseline</h2>
-            <p>The "Dopamine Baseline vs. Spike" diagram conceptually illustrates the dynamic interplay between your background dopamine levels and transient bursts. It visually represents how a rewarding event leads to a sharp increase in dopamine (a spike), which is often followed by a compensatory dip below your typical baseline before equilibrium is restored. Understanding this pattern is key to managing motivation and avoiding the "motivation hangover" from constant shallow stimulation.</p>
-            <p>For visual examples of tonic versus phasic dopamine dynamics and their impact on baseline, you can explore diagrams in review articles by authors such as Wolfram Schultz (1998, 2016) or Anna Lembke (2021). <sup><a href="#fn8" class="footnote-link">[8]</a></sup></p>
             <figure>
-              <img src="../images/placeholders/diagram_placeholder.svg" alt="Placeholder diagram for Dopamine Baseline vs. Spike - Visual representation coming soon." class="diagram-placeholder-image">
-              <figcaption><em>(Diagram: Dopamine Baseline vs. Spike - Custom visual representation coming soon.)</em></figcaption>
+                <img src="../images/diagrams/dopamine_baseline_spike.svg" alt="Diagram illustrating dopamine baseline versus spike patterns." class="diagram-visual">
+                <figcaption>Figure 1: Dopamine Baseline vs. Spike. This illustration shows how a large dopamine "spike" (orange curve) from a rewarding event is followed by a dip below the baseline (dashed line) before returning to equilibrium. Higher peaks often lead to deeper, longer troughs, reflecting a "motivation hangover." Consistent healthy habits aim to slowly raise the baseline over time, rather than relying on frequent, extreme spikes.</figcaption>
             </figure>
 
             <h2>The Stress-Reward Sensitization Loop</h2>
-            <p>The "Stress-Reward Sensitization Loop" is a flowchart illustrating how stress can trigger a cascade of events leading to impulsive reward-seeking and a subsequent degradation of mood and energy, reinforcing the cycle of stress and seeking. The diagram highlights critical "exit points" where strategic interventions can interrupt this detrimental pattern, allowing individuals to reset and regain control.</p>
-            <p>For visual representations of stress-response feedback loops and their impact on behavior, refer to models by Rajita Sinha (2007, 2024) on stress and addiction or conceptual diagrams on emotion regulation and coping mechanisms. <sup><a href="#fn9" class="footnote-link">[9]</a></sup></p>
             <figure>
-              <img src="../images/placeholders/diagram_placeholder.svg" alt="Placeholder diagram for Stress-Sensitization Loop - Visual representation coming soon." class="diagram-placeholder-image">
-              <figcaption><em>(Diagram: Stress-Sensitization Loop - Custom visual representation coming soon.)</em></figcaption>
+                <img src="../images/diagrams/stress_sensitization_loop.svg" alt="Flowchart of the Stress-Reward Sensitization Loop with intervention points." class="diagram-visual">
+                <figcaption>Figure 2: The Stress-Reward Sensitization Loop and How to Break It. This flowchart depicts how acute stress or anxiety triggers attention to quick rewards, leading to impulsive reward-seeking. This provides brief relief (a dopamine spike) but is followed by a drop in baseline mood/energy, feeding back into more stress. The diagram highlights "exit points" (grey ovals) where interventions can break the cycle, such as breathwork, exercise, social support, or mindful reflection, allowing for a reset instead of reinforcing the spiral.</figcaption>
             </figure>
         </section>
 

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -986,19 +986,14 @@ button:focus,
   100% { transform: translate(-50%, -50%) rotate(360deg); }
 }
 
-/* Placeholder Diagram Image Styling */
-.diagram-placeholder-image {
+/* General Styling for Actual Diagrams (SVG files embedded via <img>) */
+.diagram-visual {
     display: block;
     width: 100%;
-    max-width: 400px; /* Adjust based on desired size for placeholders */
+    max-width: 700px; /* Adjust max width for all diagrams as needed for consistency */
     height: auto;
     margin: var(--space-8) auto;
-    opacity: 0.7; /* Slightly faded to indicate it's a placeholder */
     border: 1px solid var(--color-border);
     border-radius: var(--border-radius-lg);
     box-shadow: var(--shadow-sm);
-    transition: opacity var(--transition-normal);
-}
-.diagram-placeholder-image:hover {
-    opacity: 1;
 }


### PR DESCRIPTION
## Summary
- Add SVG diagrams illustrating dopamine baseline vs. spike, the Ping/Scroll loop, reward compass, and stress‑reward sensitization loop.
- Replace placeholder graphics in attention, recovery, and model docs with new diagrams and captions; introduce reusable `diagram-visual` style.

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a4aec7e51c8323b9cc4a981993a196