### PR TITLE
docs: rewrite README with repo overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,68 +1,73 @@
-# Dukkha — Dopamine Cartography (research-first field guide)
+# Dukkha — Dopamine Cartography
 
-A mythic, strategic field guide that reframes dopamine beyond pop-neuro: culture, habits, meaning, and design.
+Mythic yet practical research on dopamine as a cultural and behavioural engine.
+This repository is a workspace for assembling an evidence‑grounded field guide
+and a handful of supporting design guardrails.
 
-This repository is an artifact-first workspace of curated research, claims, and source material that feed a larger project: a short, practical field guide (print + small web view) and companion design guardrails.
+## Table of contents
+
+1. [Vision](#vision)
+2. [Audience](#audience)
+3. [Repository layout](#repository-layout)
+4. [Getting started](#getting-started)
+5. [Contributing](#contributing)
+6. [QA & quality gates](#qa--quality-gates)
+7. [Roadmap](#roadmap)
+8. [License](#license)
 
 ## Vision
 
-Reframe dopamine as a cultural and behavioral engine — not just a neurotransmitter headline. Produce a compact, actionable field guide that helps readers:
-- See recurring patterns (traps, rituals, resets) across media and products.
-- Map scientific claims to practical mitigations and design ethics.
-- Use short, printable artifacts and interactive diagrams to teach and reflect.
+Reframe dopamine beyond pop‑neuro headlines. The project aims to produce a
+compact field guide that helps readers:
 
-Tone: mythic and humane — rigorous on evidence, generous on analogy, practical in mitigations.
+- Recognise recurring traps, rituals and resets in everyday products.
+- Map scientific claims to practical mitigations and design ethics.
+- Use concise printables and interactive diagrams for teaching and reflection.
+
+Tone: mythic and humane — rigorous about evidence yet generous with analogy and
+practicality.
 
 ## Audience
-- Designers and product teams building attention-sensitive experiences.
-- Practitioners interested in habit, attention, and wellbeing.
-- Curious readers who want evidence-grounded, usable explanations rather than pop summaries.
 
-## Project contract (tiny)
-- Inputs: curated papers, notes, BibTeX entries, and a handful of PDFs in `research/`.
-- Outputs: concise guide pages, print checklists, diagrams (SVG), and a minimal site/index (optional).
-- Success: a single-passable field guide that communicates core claims and mitigations in ≤ 10 minutes to a new reader.
-- Error modes: unstated claims, missing citations, outdated references.
+- Designers and product teams building attention‑sensitive experiences.
+- Practitioners interested in habit, attention and wellbeing.
+- Curious readers seeking evidence‑grounded explanations rather than pop
+  summaries.
 
-Edge cases considered: missing PDFs, partially-complete claim YAMLs, large bibliographies, private/copyrighted PDFs.
+## Repository layout
 
-## What this repo contains (current)
-This is research-first: raw notes and sources live in `research/` and are the canonical artifacts for the project.
-
-Structure (on disk):
+The workspace is artifact‑first. Raw research is canonical; everything else is
+derived from it.
 
 ```
 dukkha.code-workspace
 README.md
-research/
-  R1/  (triad: wanting / liking / learning)
-    claims.yaml
-    evidence.md
-    quotes.md
-    refs.bib
-  R2/  (traps: variable reward, doomscrolling)
-    ...
-  R3/  (myth: taṇhā / dukkha)
-    ...
-  R4/  (stress: salience, relapse)
-    ...
-  R5/  (ethics: design guardrails)
-    ...
-  R6/  (PDF: Attention & Drive in a Distracting Economy)
-  R7/  (PDF: Recovery, Stress, Sleep & the Dopamine Baseline)
+docs/        # prototype static site and assets
+pages/       # skeleton prose for eventual guide pages
+research/    # curated claims, evidence, quotes and refs
+scripts/     # QA helpers (PowerShell / batch)
+notes/       # scratch notes and planning material
 ```
 
-Files named `claims.yaml` contain distilled claims; `evidence.md` is the curated supporting notes; `refs.bib` contains BibTeX citations.
+Key research files inside each `research/Rn` folder:
 
-## How to read this repo (quick)
-- Open a claim file (e.g. `research/R1/claims.yaml`) to see the distilled claim + confidence and reference pointers.
-- Read `evidence.md` for the curated evidence and short excerpts.
-- Open PDFs with your system viewer for full sources.
+- `claims.yaml` – distilled claim, confidence and reference pointers.
+- `evidence.md` – curated supporting notes and excerpts.
+- `quotes.md` – pulled quotations for future prose.
+- `refs.bib` – BibTeX citations; PDFs live alongside when available.
 
-Example PowerShell commands (from repo root):
+## Getting started
+
+1. Browse a claim file, e.g. `research/R1/claims.yaml`, for the distilled claim
+   and references.
+2. Read `evidence.md` in the same folder for supporting excerpts.
+3. Open related PDFs with your system viewer for full context.
+4. Explore draft guide pages under `pages/` or the prototype site in `docs/`.
+
+Example PowerShell usage from the repository root:
 
 ```powershell
-# open the R1 claims YAML in the default app
+# open a claims YAML in the default app
 start .\research\R1\claims.yaml
 
 # open a PDF
@@ -72,52 +77,49 @@ start .\research\R6\"R6 - Attention & Drive in a Distracting Economy.pdf"
 Get-ChildItem .\research\ | Select-Object Name
 ```
 
-## What the field guide will (eventually) include
-- Home: a short quick-take and CTAs.
-- Triad: wanting / liking / learning — atlas SVG + claim/evidence chips.
-- Traps: variable reward, doomscrolling, and mitigations.
-- Myth: cultural framing (taṇhā / dukkha) with analogies and limits.
-- Stress: a human-first playbook linking stress → salience → relapse.
-- Ethics: design guardrails mapped to recognized taxonomies.
-- Reset: a 48-hour craving-reset checklist (print-ready).
-- Library: curated DOIs and landmark reviews.
+## Contributing
 
-## Non-goals
-- This repo will not host a large CMS or full book draft.
-- It won't attempt exhaustive citation harvesting; it curates a focused set of high-value sources.
+This project is lightweight and informal. To add or update research:
 
-## Contribution guide (short)
-- Add or update a research folder under `research/` following the existing pattern: `claims.yaml`, `evidence.md`, `quotes.md`, `refs.bib`.
-- If you add a PDF, put it under a new folder `R{n}/` and reference it in `refs.bib`.
-- Keep claims atomic and tag them with a confidence score (high/medium/low) and one-line provenance.
+1. Create or modify a folder under `research/` following the existing pattern:
+   `claims.yaml`, `evidence.md`, `quotes.md`, `refs.bib` and optional PDFs.
+2. Keep claims atomic and tag each with a confidence score and a one‑line
+   provenance statement.
+3. Add supporting excerpts to `evidence.md` with page numbers and a brief
+   explanation.
+4. Add a BibTeX entry to `refs.bib` and ensure any new PDF lives in the same
+   folder.
+5. Proofread for clarity and tone before submitting a pull request.
 
-Suggested small PR checklist:
-- [ ] Update `claims.yaml` (atomic claim, confidence, source refs)
-- [ ] Add supporting excerpt to `evidence.md` with page numbers
-- [ ] Add BibTeX entry to `refs.bib`
-- [ ] Run a quick proofread for clarity and tone
+Suggested pull‑request checklist:
 
-## Roadmap & next steps (pick one)
-- Scaffold a tiny static site generator that renders `research/*` into `site/` (Eleventy / simple Node script). Priority: index + triad page + printable reset.
-- Add a short `CONTRIBUTING.md` and examples for claim YAML structure.
-- Add `LICENSE` (recommended: MIT) if you plan to publish.
+- [ ] Update `claims.yaml` (claim, confidence, source refs).
+- [ ] Add excerpt to `evidence.md` with page numbers.
+- [ ] Add BibTeX entry to `refs.bib`.
+- [ ] Run the QA script (see below) if you touched the site.
 
-If you want, I can scaffold the site and make a first pass that renders each `claims.yaml` to a small HTML card index.
+## QA & quality gates
 
-## Quality gates
-- No build tools are required to read the repo. If we scaffold a site, we'll add a small build and CI checks.
-- When adding code or a site, include a minimal smoke test that the generated `site/index.html` exists and contains expected headings.
+No build tools are required to read the repository. For the experimental site
+in `docs/`, a small PowerShell script checks footnote anchors and (optionally)
+reference URLs:
+
+```powershell
+pwsh scripts/qa_check.ps1        # anchor/id parity only
+pwsh scripts/qa_check.ps1 -CheckUrls  # also validate reference URLs
+```
+
+When adding code or site content, include a minimal smoke test that the
+generated HTML renders the expected headings.
+
+## Roadmap
+
+- Scaffold a tiny static site generator that renders `research/*` to `docs/`.
+- Add a short `CONTRIBUTING.md` with a claim YAML example.
+- Add an explicit `LICENSE` (MIT recommended) if the project is published.
 
 ## License
-No `LICENSE` file is present in this repository. Add one if you want public reuse; I can add an MIT license file on request.
 
----
-
-If you'd like, I will now:
-- scaffold a minimal static site generator that renders `research/*` to `site/` (small Node script), or
-- add `CONTRIBUTING.md` and a claim YAML example, or
-- create a `LICENSE` file (MIT).
-
-Tell me which next step to run and I'll implement it.
-
+No dedicated `LICENSE` file is present. Add one if you plan to permit public
+reuse.
 


### PR DESCRIPTION
## Summary
- rewrite README with structured overview, repo layout and contributing notes
- document QA script and add getting started section

## Testing
- `python -m pytest`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a5f7949cac83238dc016cf5c32bc61