### PR TITLE
feat: add progress, prompts, and protocol dropdown

### DIFF
--- a/docs/site/attention.html
+++ b/docs/site/attention.html
@@ -14,6 +14,13 @@
     <link href="https://fonts.googleapis.com/css2?family=Crimson+Text:ital,wght@0,400;0,600;1,400&family=Inter:wght@300;400;500;600&display=swap" rel="stylesheet">
 </head>
 <body>
+    <div class="read-progress" aria-hidden="true">
+        <div class="read-progress__bar"></div>
+    </div>
+    <div class="read-prompt" role="status" aria-live="polite">
+        <button class="read-prompt__close" aria-label="Dismiss">&times;</button>
+        <p class="read-prompt__text"></p>
+    </div>
     <!-- Navigation -->
     <nav class="nav" role="navigation" aria-label="Main navigation">
         <div class="nav-container">
@@ -26,7 +33,10 @@
                 <li><a href="recovery.html" class="nav-link">Recovery & Baseline</a></li>
                 <li><a href="myths.html" class="nav-link">Five Myths</a></li>
                 <li><a href="model.html" class="nav-link">Model</a></li>
-                <li><a href="protocols.html" class="nav-link">Protocols</a></li>
+                <li class="nav-dropdown">
+                    <button class="nav-link nav-dropdown__toggle" aria-haspopup="true" aria-expanded="false">Protocols</button>
+                    <ul class="nav-dropdown__menu" role="menu"></ul>
+                </li>
                 <li><a href="library.html" class="nav-link">Library</a></li>
             </ul>
         </div>
@@ -113,6 +123,7 @@
         </div>
     </section>
 
+    <script src="js/site-ui.js" defer></script>
     <script>
         document.addEventListener('DOMContentLoaded', function() {
             // Footnote smooth scroll

--- a/docs/site/js/site-ui.js
+++ b/docs/site/js/site-ui.js
@@ -1,0 +1,136 @@
+(function() {
+  // reading progress
+  var bar = document.querySelector('.read-progress__bar');
+  if (bar) {
+    var updateProgress = function() {
+      var h = document.body.scrollHeight - window.innerHeight;
+      var y = window.scrollY;
+      var r = h > 0 ? y / h : 0;
+      bar.style.transform = 'scaleY(' + r + ')';
+    };
+    window.addEventListener('scroll', updateProgress, { passive: true });
+    updateProgress();
+  }
+
+  // playful prompts
+  var prompt = document.querySelector('.read-prompt');
+  if (prompt && !sessionStorage.getItem('readPromptDismissed')) {
+    var promptText = prompt.querySelector('.read-prompt__text');
+    var closeBtn = prompt.querySelector('.read-prompt__close');
+    var messages = [
+      'Keep going—you\'re doing great.',
+      'Halfway there!',
+      'Almost finished!'
+    ];
+    var thresholds = [0.25, 0.5, 0.75];
+    var shown = -1;
+    var checkPrompt = function() {
+      var h = document.body.scrollHeight - window.innerHeight;
+      var y = window.scrollY;
+      var r = h > 0 ? y / h : 0;
+      var idx = -1;
+      for (var i = 0; i < thresholds.length; i++) {
+        if (r > thresholds[i] && i > shown) { idx = i; break; }
+      }
+      if (idx !== -1) {
+        shown = idx;
+        promptText.textContent = messages[idx];
+        prompt.classList.add('active');
+      }
+    };
+    window.addEventListener('scroll', checkPrompt, { passive: true });
+    closeBtn.addEventListener('click', function() {
+      prompt.classList.remove('active');
+      sessionStorage.setItem('readPromptDismissed', '1');
+    });
+  }
+
+  // nav dropdown
+  var dropdown = document.querySelector('.nav-dropdown');
+  if (dropdown) {
+    var toggle = dropdown.querySelector('.nav-dropdown__toggle');
+    var menu = dropdown.querySelector('.nav-dropdown__menu');
+    var inProtocols = window.location.pathname.indexOf('/protocols/') !== -1;
+    var basePath = inProtocols ? '' : 'protocols/';
+    var overviewPath = inProtocols ? '../protocols.html' : 'protocols.html';
+
+    function buildMenu(list) {
+      menu.innerHTML = '';
+      var first = document.createElement('li');
+      var firstLink = document.createElement('a');
+      firstLink.href = overviewPath;
+      firstLink.textContent = 'All Protocols';
+      firstLink.setAttribute('role', 'menuitem');
+      first.appendChild(firstLink);
+      menu.appendChild(first);
+      list.forEach(function(p) {
+        var li = document.createElement('li');
+        var a = document.createElement('a');
+        a.href = basePath + p.filename;
+        a.textContent = p.title;
+        a.setAttribute('role', 'menuitem');
+        li.appendChild(a);
+        menu.appendChild(li);
+      });
+    }
+
+    fetch(basePath + 'manifest.json')
+      .then(function(r) { return r.json(); })
+      .then(function(data) { buildMenu(data.protocols || []); })
+      .catch(function() {
+        buildMenu([
+          {title:'Digital Detox Protocol', filename:'digital-detox-protocol.html'},
+          {title:'Mindfulness & Awareness Protocol', filename:'mindfulness-awareness-protocol.html'},
+          {title:'Nutrition & Supplementation Protocol', filename:'nutrition-supplementation-protocol.html'},
+          {title:'Sleep Optimization Protocol', filename:'sleep-optimization-protocol.html'},
+          {title:'Stress Management Protocol', filename:'stress-management-protocol.html'}
+        ]);
+      });
+
+    function getItems() {
+      return Array.prototype.slice.call(menu.querySelectorAll('a'));
+    }
+    function open() {
+      dropdown.classList.add('open');
+      toggle.setAttribute('aria-expanded', 'true');
+    }
+    function close() {
+      dropdown.classList.remove('open');
+      toggle.setAttribute('aria-expanded', 'false');
+    }
+
+    toggle.addEventListener('click', function(e) {
+      e.preventDefault();
+      var isOpen = dropdown.classList.toggle('open');
+      toggle.setAttribute('aria-expanded', isOpen);
+      if (isOpen) { getItems()[0] && getItems()[0].focus(); }
+    });
+    toggle.addEventListener('keydown', function(e) {
+      if (e.key === 'ArrowDown') { e.preventDefault(); open(); getItems()[0] && getItems()[0].focus(); }
+    });
+    dropdown.addEventListener('mouseenter', open);
+    dropdown.addEventListener('mouseleave', close);
+
+    menu.addEventListener('keydown', function(e) {
+      var items = getItems();
+      var current = items.indexOf(document.activeElement);
+      if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        items[(current + 1) % items.length].focus();
+      } else if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        items[(current - 1 + items.length) % items.length].focus();
+      } else if (e.key === 'Escape') {
+        e.preventDefault();
+        close();
+        toggle.focus();
+      } else if (e.key === 'Tab') {
+        if (!e.shiftKey && current === items.length - 1) { e.preventDefault(); toggle.focus(); }
+        if (e.shiftKey && current === 0) { e.preventDefault(); toggle.focus(); }
+      }
+    });
+    document.addEventListener('click', function(e) {
+      if (!dropdown.contains(e.target)) { close(); }
+    });
+  }
+})();

--- a/docs/site/library.html
+++ b/docs/site/library.html
@@ -26,7 +26,10 @@
                 <li><a href="recovery.html" class="nav-link">Recovery & Baseline</a></li>
                 <li><a href="myths.html" class="nav-link">Five Myths</a></li>
                 <li><a href="model.html" class="nav-link">Model</a></li>
-                <li><a href="protocols.html" class="nav-link">Protocols</a></li>
+                <li class="nav-dropdown">
+                <button class="nav-link nav-dropdown__toggle" aria-haspopup="true" aria-expanded="false">Protocols</button>
+                <ul class="nav-dropdown__menu" role="menu"></ul>
+            </li>
                 <li><a href="library.html" class="nav-link active" aria-current="page">Library</a></li>
             </ul>
         </div>
@@ -84,6 +87,7 @@
         </div>
     </footer>
 
+    <script src="js/site-ui.js" defer></script>
     <script>
         document.addEventListener('DOMContentLoaded', function() {
             // Smooth navigation highlighting

--- a/docs/site/model.html
+++ b/docs/site/model.html
@@ -26,7 +26,10 @@
                 <li><a href="recovery.html" class="nav-link">Recovery & Baseline</a></li>
                 <li><a href="myths.html" class="nav-link">Five Myths</a></li>
                 <li><a href="model.html" class="nav-link active" aria-current="page">Model</a></li>
-                <li><a href="protocols.html" class="nav-link">Protocols</a></li>
+                <li class="nav-dropdown">
+                <button class="nav-link nav-dropdown__toggle" aria-haspopup="true" aria-expanded="false">Protocols</button>
+                <ul class="nav-dropdown__menu" role="menu"></ul>
+            </li>
                 <li><a href="library.html" class="nav-link">Library</a></li>
             </ul>
         </div>
@@ -127,6 +130,7 @@
         </div>
     </section>
 
+    <script src="js/site-ui.js" defer></script>
     <script>
         document.addEventListener('DOMContentLoaded', function() {
             // Footnote smooth scroll

--- a/docs/site/myths.html
+++ b/docs/site/myths.html
@@ -26,7 +26,10 @@
                 <li><a href="recovery.html" class="nav-link">Recovery & Baseline</a></li>
                 <li><a href="myths.html" class="nav-link active" aria-current="page">Five Myths</a></li>
                 <li><a href="model.html" class="nav-link">Model</a></li>
-                <li><a href="protocols.html" class="nav-link">Protocols</a></li>
+                <li class="nav-dropdown">
+                <button class="nav-link nav-dropdown__toggle" aria-haspopup="true" aria-expanded="false">Protocols</button>
+                <ul class="nav-dropdown__menu" role="menu"></ul>
+            </li>
                 <li><a href="library.html" class="nav-link">Library</a></li>
             </ul>
         </div>
@@ -129,6 +132,7 @@
             </ol>
     </section>
 
+    <script src="js/site-ui.js" defer></script>
     <script>
         document.addEventListener('DOMContentLoaded', function() {
             // Footnote smooth scroll

--- a/docs/site/protocols.html
+++ b/docs/site/protocols.html
@@ -26,7 +26,10 @@
                 <li><a href="recovery.html" class="nav-link">Recovery & Baseline</a></li>
                 <li><a href="myths.html" class="nav-link">Five Myths</a></li>
                 <li><a href="model.html" class="nav-link">Model</a></li>
-                <li><a href="protocols.html" class="nav-link active" aria-current="page">Protocols</a></li>
+                <li class="nav-dropdown">
+                <button class="nav-link nav-dropdown__toggle" aria-haspopup="true" aria-expanded="false">Protocols</button>
+                <ul class="nav-dropdown__menu" role="menu"></ul>
+            </li>
                 <li><a href="library.html" class="nav-link">Library</a></li>
             </ul>
         </div>
@@ -99,6 +102,7 @@
         </div>
     </footer>
 
+    <script src="js/site-ui.js" defer></script>
     <script>
         document.addEventListener('DOMContentLoaded', function() {
             const navLinks = document.querySelectorAll('.nav-link');

--- a/docs/site/protocols/digital-detox-protocol.html
+++ b/docs/site/protocols/digital-detox-protocol.html
@@ -26,7 +26,10 @@
                 <li><a href="../recovery.html" class="nav-link">Recovery & Baseline</a></li>
                 <li><a href="../myths.html" class="nav-link">Five Myths</a></li>
                 <li><a href="../model.html" class="nav-link">Model</a></li>
-                <li><a href="../protocols.html" class="nav-link">Protocols</a></li>
+                <li class="nav-dropdown">
+                    <button class="nav-link nav-dropdown__toggle" aria-haspopup="true" aria-expanded="false">Protocols</button>
+                    <ul class="nav-dropdown__menu" role="menu"></ul>
+                </li>
                 <li><a href="../library.html" class="nav-link">Library</a></li>
             </ul>
         </div>
@@ -116,6 +119,7 @@
         </div>
     </section>
 
+    <script src="../js/site-ui.js" defer></script>
     <script>
         document.addEventListener('DOMContentLoaded', function() {
             // Footnote smooth scroll

--- a/docs/site/protocols/mindfulness-awareness-protocol.html
+++ b/docs/site/protocols/mindfulness-awareness-protocol.html
@@ -26,7 +26,10 @@
                 <li><a href="../recovery.html" class="nav-link">Recovery & Baseline</a></li>
                 <li><a href="../myths.html" class="nav-link">Five Myths</a></li>
                 <li><a href="../model.html" class="nav-link">Model</a></li>
-                <li><a href="../protocols.html" class="nav-link">Protocols</a></li>
+                <li class="nav-dropdown">
+                    <button class="nav-link nav-dropdown__toggle" aria-haspopup="true" aria-expanded="false">Protocols</button>
+                    <ul class="nav-dropdown__menu" role="menu"></ul>
+                </li>
                 <li><a href="../library.html" class="nav-link">Library</a></li>
             </ul>
         </div>
@@ -119,6 +122,7 @@
         </div>
     </section>
 
+    <script src="../js/site-ui.js" defer></script>
     <script>
         document.addEventListener('DOMContentLoaded', function() {
             // Footnote smooth scroll

--- a/docs/site/protocols/nutrition-supplementation-protocol.html
+++ b/docs/site/protocols/nutrition-supplementation-protocol.html
@@ -26,7 +26,10 @@
                 <li><a href="../recovery.html" class="nav-link">Recovery & Baseline</a></li>
                 <li><a href="../myths.html" class="nav-link">Five Myths</a></li>
                 <li><a href="../model.html" class="nav-link">Model</a></li>
-                <li><a href="../protocols.html" class="nav-link">Protocols</a></li>
+                <li class="nav-dropdown">
+                    <button class="nav-link nav-dropdown__toggle" aria-haspopup="true" aria-expanded="false">Protocols</button>
+                    <ul class="nav-dropdown__menu" role="menu"></ul>
+                </li>
                 <li><a href="../library.html" class="nav-link">Library</a></li>
             </ul>
         </div>
@@ -135,6 +138,7 @@ Curcumin: Found in turmeric, curcumin may increase dopamine and serotonin and ha
         </div>
     </section>
 
+    <script src="../js/site-ui.js" defer></script>
     <script>
         document.addEventListener('DOMContentLoaded', function() {
             // Footnote smooth scroll

--- a/docs/site/protocols/sleep-optimization-protocol.html
+++ b/docs/site/protocols/sleep-optimization-protocol.html
@@ -26,7 +26,10 @@
                 <li><a href="../recovery.html" class="nav-link">Recovery & Baseline</a></li>
                 <li><a href="../myths.html" class="nav-link">Five Myths</a></li>
                 <li><a href="../model.html" class="nav-link">Model</a></li>
-                <li><a href="../protocols.html" class="nav-link">Protocols</a></li>
+                <li class="nav-dropdown">
+                    <button class="nav-link nav-dropdown__toggle" aria-haspopup="true" aria-expanded="false">Protocols</button>
+                    <ul class="nav-dropdown__menu" role="menu"></ul>
+                </li>
                 <li><a href="../library.html" class="nav-link">Library</a></li>
             </ul>
         </div>
@@ -119,6 +122,7 @@ Quiet: Use earplugs or a white noise machine/fan to block noise.</p>
         </div>
     </section>
 
+    <script src="../js/site-ui.js" defer></script>
     <script>
         document.addEventListener('DOMContentLoaded', function() {
             // Footnote smooth scroll

--- a/docs/site/protocols/stress-management-protocol.html
+++ b/docs/site/protocols/stress-management-protocol.html
@@ -26,7 +26,10 @@
                 <li><a href="../recovery.html" class="nav-link">Recovery & Baseline</a></li>
                 <li><a href="../myths.html" class="nav-link">Five Myths</a></li>
                 <li><a href="../model.html" class="nav-link">Model</a></li>
-                <li><a href="../protocols.html" class="nav-link">Protocols</a></li>
+                <li class="nav-dropdown">
+                    <button class="nav-link nav-dropdown__toggle" aria-haspopup="true" aria-expanded="false">Protocols</button>
+                    <ul class="nav-dropdown__menu" role="menu"></ul>
+                </li>
                 <li><a href="../library.html" class="nav-link">Library</a></li>
             </ul>
         </div>
@@ -108,6 +111,7 @@
         </div>
     </section>
 
+    <script src="../js/site-ui.js" defer></script>
     <script>
         document.addEventListener('DOMContentLoaded', function() {
             // Footnote smooth scroll

--- a/docs/site/recovery.html
+++ b/docs/site/recovery.html
@@ -26,7 +26,10 @@
                 <li><a href="recovery.html" class="nav-link active" aria-current="page">Recovery & Baseline</a></li>
                 <li><a href="myths.html" class="nav-link">Five Myths</a></li>
                 <li><a href="model.html" class="nav-link">Model</a></li>
-                <li><a href="protocols.html" class="nav-link">Protocols</a></li>
+                <li class="nav-dropdown">
+                <button class="nav-link nav-dropdown__toggle" aria-haspopup="true" aria-expanded="false">Protocols</button>
+                <ul class="nav-dropdown__menu" role="menu"></ul>
+            </li>
                 <li><a href="library.html" class="nav-link">Library</a></li>
             </ul>
         </div>
@@ -121,6 +124,7 @@
         </div>
     </section>
 
+    <script src="js/site-ui.js" defer></script>
     <script>
         document.addEventListener('DOMContentLoaded', function() {
             // Footnote smooth scroll

--- a/docs/utilities.css
+++ b/docs/utilities.css
@@ -129,3 +129,87 @@ details.protocol-summary summary {
 details.protocol-summary[open] { 
   background: rgba(0,0,0,0.02); 
 }
+
+/* =============================================
+   Reading Progress & Prompt & Dropdown
+   ============================================= */
+
+.read-progress {
+  position: fixed;
+  top: 0;
+  right: 0;
+  width: 4px;
+  height: 100vh;
+  background: var(--color-border);
+  pointer-events: none;
+  z-index: 1000;
+}
+.read-progress__bar {
+  width: 100%;
+  height: 100%;
+  background: var(--color-accent);
+  transform-origin: top;
+  transform: scaleY(0);
+}
+@media (max-width: 767px) {
+  .read-progress { display: none; }
+}
+
+.read-prompt {
+  position: fixed;
+  bottom: var(--space-4);
+  right: var(--space-4);
+  max-width: 280px;
+  background: var(--color-surface-elevated);
+  border: 1px solid var(--color-border);
+  border-radius: var(--border-radius);
+  padding: var(--space-3) var(--space-4);
+  box-shadow: var(--shadow-md);
+  display: none;
+}
+.read-prompt.active { display: block; }
+.read-prompt__close {
+  position: absolute;
+  top: var(--space-1);
+  right: var(--space-1);
+  background: none;
+  border: none;
+  font-size: var(--text-lg);
+  line-height: 1;
+  cursor: pointer;
+}
+.read-prompt__close:focus { outline: 2px solid var(--color-accent); }
+
+.nav-dropdown { position: relative; }
+.nav-dropdown__toggle {
+  background: none;
+  border: none;
+  cursor: pointer;
+}
+.nav-dropdown__toggle:focus { outline: 2px solid var(--color-accent); }
+.nav-dropdown__menu {
+  position: absolute;
+  left: 0;
+  top: 100%;
+  background: var(--color-surface-elevated);
+  border: 1px solid var(--color-border);
+  border-radius: var(--border-radius);
+  padding: var(--space-2) 0;
+  margin-top: var(--space-2);
+  display: none;
+  min-width: 200px;
+  z-index: 200;
+}
+.nav-dropdown.open .nav-dropdown__menu { display: block; }
+.nav-dropdown__menu li { list-style: none; }
+.nav-dropdown__menu a {
+  display: block;
+  padding: var(--space-2) var(--space-4);
+  color: var(--color-text-primary);
+}
+.nav-dropdown__menu a:focus {
+  outline: 2px solid var(--color-accent);
+  outline-offset: -2px;
+  background: var(--color-surface);
+}
+


### PR DESCRIPTION
## Summary
- show a scroll-based reading progress bar and playful prompts on the attention page
- add an accessible protocols dropdown populated from the manifest
- style and script new components for progressive enhancement

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'bs4', 'requests'; attempted `pip install beautifulsoup4 requests` but received proxy 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a6820e00e88323b45bf89b9efcecbd