### PR TITLE
Enhance protocols menu and add reading progress bar

### DIFF
--- a/docs/site/attention.html
+++ b/docs/site/attention.html
@@ -14,9 +14,6 @@
     <link href="https://fonts.googleapis.com/css2?family=Crimson+Text:ital,wght@0,400;0,600;1,400&family=Inter:wght@300;400;500;600&display=swap" rel="stylesheet">
 </head>
 <body>
-    <div class="read-progress" aria-hidden="true">
-        <div class="read-progress__bar"></div>
-    </div>
     <div class="read-prompt" role="status" aria-live="polite">
         <button class="read-prompt__close" aria-label="Dismiss">&times;</button>
         <p class="read-prompt__text"></p>
@@ -34,7 +31,7 @@
                 <li><a href="myths.html" class="nav-link">Five Myths</a></li>
                 <li><a href="model.html" class="nav-link">Model</a></li>
                 <li class="nav-dropdown">
-                    <button class="nav-link nav-dropdown__toggle" aria-haspopup="true" aria-expanded="false">Protocols</button>
+                    <a href="#" class="nav-link nav-dropdown__toggle" aria-haspopup="true" aria-expanded="false">Protocols</a>
                     <ul class="nav-dropdown__menu" role="menu"></ul>
                 </li>
                 <li><a href="library.html" class="nav-link">Library</a></li>

--- a/docs/site/library.html
+++ b/docs/site/library.html
@@ -27,7 +27,7 @@
                 <li><a href="myths.html" class="nav-link">Five Myths</a></li>
                 <li><a href="model.html" class="nav-link">Model</a></li>
                 <li class="nav-dropdown">
-                <button class="nav-link nav-dropdown__toggle" aria-haspopup="true" aria-expanded="false">Protocols</button>
+                <a href="#" class="nav-link nav-dropdown__toggle" aria-haspopup="true" aria-expanded="false">Protocols</a>
                 <ul class="nav-dropdown__menu" role="menu"></ul>
             </li>
                 <li><a href="library.html" class="nav-link active" aria-current="page">Library</a></li>

--- a/docs/site/model.html
+++ b/docs/site/model.html
@@ -27,7 +27,7 @@
                 <li><a href="myths.html" class="nav-link">Five Myths</a></li>
                 <li><a href="model.html" class="nav-link active" aria-current="page">Model</a></li>
                 <li class="nav-dropdown">
-                <button class="nav-link nav-dropdown__toggle" aria-haspopup="true" aria-expanded="false">Protocols</button>
+                <a href="#" class="nav-link nav-dropdown__toggle" aria-haspopup="true" aria-expanded="false">Protocols</a>
                 <ul class="nav-dropdown__menu" role="menu"></ul>
             </li>
                 <li><a href="library.html" class="nav-link">Library</a></li>

--- a/docs/site/myths.html
+++ b/docs/site/myths.html
@@ -27,7 +27,7 @@
                 <li><a href="myths.html" class="nav-link active" aria-current="page">Five Myths</a></li>
                 <li><a href="model.html" class="nav-link">Model</a></li>
                 <li class="nav-dropdown">
-                <button class="nav-link nav-dropdown__toggle" aria-haspopup="true" aria-expanded="false">Protocols</button>
+                <a href="#" class="nav-link nav-dropdown__toggle" aria-haspopup="true" aria-expanded="false">Protocols</a>
                 <ul class="nav-dropdown__menu" role="menu"></ul>
             </li>
                 <li><a href="library.html" class="nav-link">Library</a></li>

--- a/docs/site/protocols.html
+++ b/docs/site/protocols.html
@@ -27,7 +27,7 @@
                 <li><a href="myths.html" class="nav-link">Five Myths</a></li>
                 <li><a href="model.html" class="nav-link">Model</a></li>
                 <li class="nav-dropdown">
-                <button class="nav-link nav-dropdown__toggle" aria-haspopup="true" aria-expanded="false">Protocols</button>
+                <a href="#" class="nav-link nav-dropdown__toggle" aria-haspopup="true" aria-expanded="false">Protocols</a>
                 <ul class="nav-dropdown__menu" role="menu"></ul>
             </li>
                 <li><a href="library.html" class="nav-link">Library</a></li>

--- a/docs/site/protocols/digital-detox-protocol.html
+++ b/docs/site/protocols/digital-detox-protocol.html
@@ -27,7 +27,7 @@
                 <li><a href="../myths.html" class="nav-link">Five Myths</a></li>
                 <li><a href="../model.html" class="nav-link">Model</a></li>
                 <li class="nav-dropdown">
-                    <button class="nav-link nav-dropdown__toggle" aria-haspopup="true" aria-expanded="false">Protocols</button>
+                    <a href="#" class="nav-link nav-dropdown__toggle" aria-haspopup="true" aria-expanded="false">Protocols</a>
                     <ul class="nav-dropdown__menu" role="menu"></ul>
                 </li>
                 <li><a href="../library.html" class="nav-link">Library</a></li>

--- a/docs/site/protocols/mindfulness-awareness-protocol.html
+++ b/docs/site/protocols/mindfulness-awareness-protocol.html
@@ -27,7 +27,7 @@
                 <li><a href="../myths.html" class="nav-link">Five Myths</a></li>
                 <li><a href="../model.html" class="nav-link">Model</a></li>
                 <li class="nav-dropdown">
-                    <button class="nav-link nav-dropdown__toggle" aria-haspopup="true" aria-expanded="false">Protocols</button>
+                    <a href="#" class="nav-link nav-dropdown__toggle" aria-haspopup="true" aria-expanded="false">Protocols</a>
                     <ul class="nav-dropdown__menu" role="menu"></ul>
                 </li>
                 <li><a href="../library.html" class="nav-link">Library</a></li>

--- a/docs/site/protocols/nutrition-supplementation-protocol.html
+++ b/docs/site/protocols/nutrition-supplementation-protocol.html
@@ -27,7 +27,7 @@
                 <li><a href="../myths.html" class="nav-link">Five Myths</a></li>
                 <li><a href="../model.html" class="nav-link">Model</a></li>
                 <li class="nav-dropdown">
-                    <button class="nav-link nav-dropdown__toggle" aria-haspopup="true" aria-expanded="false">Protocols</button>
+                    <a href="#" class="nav-link nav-dropdown__toggle" aria-haspopup="true" aria-expanded="false">Protocols</a>
                     <ul class="nav-dropdown__menu" role="menu"></ul>
                 </li>
                 <li><a href="../library.html" class="nav-link">Library</a></li>

--- a/docs/site/protocols/sleep-optimization-protocol.html
+++ b/docs/site/protocols/sleep-optimization-protocol.html
@@ -27,7 +27,7 @@
                 <li><a href="../myths.html" class="nav-link">Five Myths</a></li>
                 <li><a href="../model.html" class="nav-link">Model</a></li>
                 <li class="nav-dropdown">
-                    <button class="nav-link nav-dropdown__toggle" aria-haspopup="true" aria-expanded="false">Protocols</button>
+                    <a href="#" class="nav-link nav-dropdown__toggle" aria-haspopup="true" aria-expanded="false">Protocols</a>
                     <ul class="nav-dropdown__menu" role="menu"></ul>
                 </li>
                 <li><a href="../library.html" class="nav-link">Library</a></li>

--- a/docs/site/protocols/stress-management-protocol.html
+++ b/docs/site/protocols/stress-management-protocol.html
@@ -27,7 +27,7 @@
                 <li><a href="../myths.html" class="nav-link">Five Myths</a></li>
                 <li><a href="../model.html" class="nav-link">Model</a></li>
                 <li class="nav-dropdown">
-                    <button class="nav-link nav-dropdown__toggle" aria-haspopup="true" aria-expanded="false">Protocols</button>
+                    <a href="#" class="nav-link nav-dropdown__toggle" aria-haspopup="true" aria-expanded="false">Protocols</a>
                     <ul class="nav-dropdown__menu" role="menu"></ul>
                 </li>
                 <li><a href="../library.html" class="nav-link">Library</a></li>

--- a/docs/site/recovery.html
+++ b/docs/site/recovery.html
@@ -27,7 +27,7 @@
                 <li><a href="myths.html" class="nav-link">Five Myths</a></li>
                 <li><a href="model.html" class="nav-link">Model</a></li>
                 <li class="nav-dropdown">
-                <button class="nav-link nav-dropdown__toggle" aria-haspopup="true" aria-expanded="false">Protocols</button>
+                <a href="#" class="nav-link nav-dropdown__toggle" aria-haspopup="true" aria-expanded="false">Protocols</a>
                 <ul class="nav-dropdown__menu" role="menu"></ul>
             </li>
                 <li><a href="library.html" class="nav-link">Library</a></li>

--- a/docs/utilities.css
+++ b/docs/utilities.css
@@ -137,22 +137,25 @@ details.protocol-summary[open] {
 .read-progress {
   position: fixed;
   top: 0;
-  right: 0;
-  width: 4px;
-  height: 100vh;
+  left: 0;
+  width: 100%;
+  height: 4px;
   background: var(--color-border);
   pointer-events: none;
   z-index: 1000;
+  display: none;
+}
+.read-progress.visible {
+  display: block;
 }
 .read-progress__bar {
-  width: 100%;
+  width: 0;
   height: 100%;
   background: var(--color-accent);
-  transform-origin: top;
-  transform: scaleY(0);
 }
 @media (max-width: 767px) {
   .read-progress { display: none; }
+  .read-progress.visible { display: none; }
 }
 
 .read-prompt {


### PR DESCRIPTION
## Summary
- Keep protocol dropdown open briefly when the cursor leaves and navigate to protocols overview on click
- Implement minimal scroll progress bar that appears beneath the fixed nav after the hero section
- Convert "Protocols" nav item to a link and drop redundant “All Protocols” menu entry

## Testing
- `pytest -q` *(fails: No module named 'bs4'; attempts to install dependencies were blocked by network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68a71b9b49a08323869d5c172074d161