### PR TITLE
Add dual licensing for code and content

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,49 @@
+# License
+
+## Code
+
+### MIT License
+
+Copyright (c) 2025 Benjamin Haddon (GitHub: BenWassa)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+## Content
+
+All text, research briefs, site copy, podcast scripts, generated images, and
+other creative or narrative work in this repository are licensed under the
+Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International
+(CC BY-NC-ND 4.0) license.
+
+You are allowed to:
+- Share — copy and redistribute the material in any medium or format.
+
+You are not allowed to:
+- Use the material for commercial purposes.
+- Distribute modified versions of the content.
+
+Please credit: Benjamin Haddon (GitHub: BenWassa).
+
+For the full legal text, visit <https://creativecommons.org/licenses/by-nc-nd/4.0/>.
+
+## Summary
+
+- Code is licensed under the MIT License.
+- Content is licensed under CC BY-NC-ND 4.0.
+- Please credit: Benjamin Haddon (GitHub: BenWassa).

--- a/README.md
+++ b/README.md
@@ -327,7 +327,9 @@ python scripts/build_site.py
 
 ## 📄 License
 
-This project is released under the MIT License - see the LICENSE file for details.
+Code in this repository is licensed under the MIT License, and all content is
+licensed under the Creative Commons Attribution-NonCommercial-NoDerivatives 4.0
+International License. See LICENSE.md for details.
 
 ## 🕘 Recent Activity
 


### PR DESCRIPTION
## Summary
- add comprehensive `LICENSE.md` with MIT for code and CC BY-NC-ND 4.0 for creative content
- update README to clarify dual licensing and point to new license file

## Testing
- `pip install beautifulsoup4 requests` *(failed: Could not connect to proxy, no matching distribution found)*
- `python -m pytest tests/ -v` *(fails: ModuleNotFoundError for bs4 and requests)*

------
https://chatgpt.com/codex/tasks/task_e_68b9bad7d29c8323b98d445efe40af96